### PR TITLE
More reliable pre-Windows 8 IE checks if navigator.userAgent can also be set by custom protocol handler

### DIFF
--- a/protocolcheck.js
+++ b/protocolcheck.js
@@ -93,12 +93,26 @@
     }
 
     function openUriUsingIEInOlderWindows(uri, failCb, successCb) {
-        if (getInternetExplorerVersion() === 10) {
-            openUriUsingIE10InWindows7(uri, failCb, successCb);
-        } else if (getInternetExplorerVersion() === 9 || getInternetExplorerVersion() === 11) {
-            openUriWithHiddenFrame(uri, failCb, successCb);
+    	var iframe;
+    	// If your application has the luxury of adding a custom string to navigator.userAgent via the registry,
+    	// check for it here first.
+        if (navigator.userAgent != null && navigator.userAgent.indexOf(uri.substr(0, uri.indexOf('://'))) !== -1) {
+        	if (getInternetExplorerVersion() <= 8) {
+    	        openUriInNewWindowHack(uri, failCb, successCb);
+        	} else {
+	            iframe = _createHiddenIframe(document.body, "about:blank");
+    	        iframe.contentWindow.location.href = uri;
+        		successCb();
+        	}
         } else {
-            openUriInNewWindowHack(uri, failCb, successCb);
+        	// Can't determine from custom string in navigator.userAgent. Fallback to other methods
+	        if (getInternetExplorerVersion() === 10) {
+    	        openUriUsingIE10InWindows7(uri, failCb, successCb);
+        	} else if (getInternetExplorerVersion() === 9 || getInternetExplorerVersion() === 11) {
+            	openUriWithHiddenFrame(uri, failCb, successCb);
+	        } else {
+    	        openUriInNewWindowHack(uri, failCb, successCb);
+        	}
         }
     }
 


### PR DESCRIPTION
Check for custom identifier in navigator.userAgent in pre-Windows 8 IE tests. This works if your custom protocol handler had the ability to add a custom string to the IE userAgent via the Windows registry.

See https://msdn.microsoft.com/en-us/library/ms537503(v=vs.85).aspx
