### PR TITLE
Fallback to useragent to detect brower

### DIFF
--- a/protocolcheck.js
+++ b/protocolcheck.js
@@ -150,7 +150,7 @@ function checkBrowser() {
         isOpera   : isOpera,
         isFirefox : typeof InstallTrigger !== 'undefined',
         isSafari  : Object.prototype.toString.call(window.HTMLElement).indexOf('Constructor') > 0,
-        isChrome  : !!window.chrome && !isOpera,
+        isChrome  : (!!window.chrome || / Chrome\//.test(window.navigator.appVersion)) && !isOpera,
         isIE      : /*@cc_on!@*/false || !!document.documentMode // At least IE6
     }
 }


### PR DESCRIPTION
https://beakerbrowser.com/ is an electron app, it mostly works like Chrome but window.chrome isn't defined.

With this patch, your module works in Beaker too, and probably other Electron apps.