### PR TITLE
Add support for custom timeouts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10

--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@ The implementation is different from one browser to another, sometimes depend on
 * IEs and Edge in Win 8/Win 10: the cleanest solution. IEs and Edge in Windows 8 and Windows 10 does provide an API to check the existence of custom protocol handlers.
 * Other IEs: various different implementation. Worth to notice that even the same IE version might have a different behavior (I suspect due to different commit number). It means that for these IEs, the implementation is the least reliable.
 
+### Note:
+In addition to providing callback functions for failure, success, and
+unsupported browsers, you may also provide an optional `timeouts` argument that
+controls how long the browser waits for timeout-based checks (currently Chrome,
+IOS, legacy IE, and Safari use timeouts). The timeouts argument is an object in
+the following format:
+```
+{
+    chromeAndIOS: <intTimeoutInMs>,
+    legacyIE:     <intTimeoutInMs>,
+    safari:       <intTimeoutInMs>
+}
+```
+
 # Known Issues
 
 * In some protocol such as "mailto:", IE seems to trigger the fail callback while continuing on opening the protocol just fine (tested in IE11/Win 10). This issue doesn't occur with a custom protocol.

--- a/index.js
+++ b/index.js
@@ -26,12 +26,12 @@ function _createHiddenIframe(target, uri) {
     return iframe;
 }
 
-function openUriWithHiddenFrame(uri, failCb, successCb) {
+function openUriWithHiddenFrame(uri, failCb, successCb, timeoutMs) {
 
     var timeout = setTimeout(function () {
         failCb();
         handler.remove();
-    }, 1000);
+    }, timeoutMs);
 
     var iframe = document.querySelector("#hiddenIframe");
     if (!iframe) {
@@ -49,12 +49,12 @@ function openUriWithHiddenFrame(uri, failCb, successCb) {
     iframe.contentWindow.location.href = uri;
 }
 
-function openUriWithTimeoutHack(uri, failCb, successCb) {
+function openUriWithTimeoutHack(uri, failCb, successCb, timeoutMs) {
     
     var timeout = setTimeout(function () {
         failCb();
         handler.remove();
-    }, 1000);
+    }, timeoutMs);
 
     //handle page running in an iframe (blur must be registered with top level window)
     var target = window;
@@ -90,18 +90,18 @@ function openUriUsingFirefox(uri, failCb, successCb) {
     }
 }
 
-function openUriUsingIEInOlderWindows(uri, failCb, successCb) {
+function openUriUsingIEInOlderWindows(uri, failCb, successCb, timeoutMs) {
     if (getInternetExplorerVersion() === 10) {
-        openUriUsingIE10InWindows7(uri, failCb, successCb);
+        openUriUsingIE10InWindows7(uri, failCb, successCb, timeoutMs);
     } else if (getInternetExplorerVersion() === 9 || getInternetExplorerVersion() === 11) {
-        openUriWithHiddenFrame(uri, failCb, successCb);
+        openUriWithHiddenFrame(uri, failCb, successCb, timeoutMs);
     } else {
-        openUriInNewWindowHack(uri, failCb, successCb);
+        openUriInNewWindowHack(uri, failCb, successCb, timeoutMs);
     }
 }
 
-function openUriUsingIE10InWindows7(uri, failCb, successCb) {
-    var timeout = setTimeout(failCb, 1000);
+function openUriUsingIE10InWindows7(uri, failCb, successCb, timeoutMs) {
+    var timeout = setTimeout(failCb, timeoutMs);
     window.addEventListener("blur", function () {
         clearTimeout(timeout);
         successCb();
@@ -119,7 +119,7 @@ function openUriUsingIE10InWindows7(uri, failCb, successCb) {
     }
 }
 
-function openUriInNewWindowHack(uri, failCb, successCb) {
+function openUriInNewWindowHack(uri, failCb, successCb, timeoutMs) {
     var myWindow = window.open('', '', 'width=0,height=0');
 
     myWindow.document.write("<iframe src='" + uri + "'></iframe>");
@@ -127,13 +127,13 @@ function openUriInNewWindowHack(uri, failCb, successCb) {
     setTimeout(function () {
         try {
             myWindow.location.href;
-            myWindow.setTimeout("window.close()", 1000);
+            myWindow.setTimeout("window.close()", timeoutMs);
             successCb();
         } catch (e) {
             myWindow.close();
             failCb();
         }
-    }, 1000);
+    }, timeoutMs);
 }
 
 function openUriWithMsLaunchUri(uri, failCb, successCb) {
@@ -174,7 +174,15 @@ function getInternetExplorerVersion() {
     return rv;
 }
 
-module.exports = function(uri, failCb, successCb, unsupportedCb) {
+function getTimeouts(timeouts) {
+    return {
+        chromeAndIOS: parseInt(timeouts.chromeAndIOS) || 1000,
+        legacyIE: parseInt(timeouts.legacyIE) || 1000,
+        safari: parseInt(timeouts.safari) || 1000
+    };
+}
+
+module.exports = function(uri, failCb, successCb, unsupportedCb, timeouts) {
     function failCallback() {
         failCb && failCb();
     }
@@ -182,6 +190,8 @@ module.exports = function(uri, failCb, successCb, unsupportedCb) {
     function successCallback() {
         successCb && successCb();
     }
+
+    timeouts = getTimeouts(timeouts);
 
     if (navigator.msLaunchUri) { //for IE and Edge in Win 8 and Win 10
         openUriWithMsLaunchUri(uri, failCb, successCb);
@@ -191,11 +201,11 @@ module.exports = function(uri, failCb, successCb, unsupportedCb) {
         if (browser.isFirefox) {
             openUriUsingFirefox(uri, failCallback, successCallback);
         } else if (browser.isChrome || browser.isIOS) {
-            openUriWithTimeoutHack(uri, failCallback, successCallback);
+            openUriWithTimeoutHack(uri, failCallback, successCallback, timeouts.chromeAndIOS);
         } else if (browser.isIE) {
-            openUriUsingIEInOlderWindows(uri, failCallback, successCallback);
+            openUriUsingIEInOlderWindows(uri, failCallback, successCallback, timeouts.legacyIE);
         } else if (browser.isSafari) {
-            openUriWithHiddenFrame(uri, failCallback, successCallback);
+            openUriWithHiddenFrame(uri, failCallback, successCallback, timeouts.safari);
         } else {
             unsupportedCb();
             //not supported, implement please

--- a/index.js
+++ b/index.js
@@ -175,6 +175,11 @@ function getInternetExplorerVersion() {
 }
 
 function getTimeouts(timeouts) {
+    timeouts = timeouts || {
+        chromeAndIOS: 1000,
+        legacyIE: 1000,
+        safari: 1000
+    };
     return {
         chromeAndIOS: parseInt(timeouts.chromeAndIOS) || 1000,
         legacyIE: parseInt(timeouts.legacyIE) || 1000,

--- a/index.js
+++ b/index.js
@@ -175,11 +175,7 @@ function getInternetExplorerVersion() {
 }
 
 function getTimeouts(timeouts) {
-    timeouts = timeouts || {
-        chromeAndIOS: 1000,
-        legacyIE: 1000,
-        safari: 1000
-    };
+    timeouts = timeouts || {};
     return {
         chromeAndIOS: parseInt(timeouts.chromeAndIOS) || 1000,
         legacyIE: parseInt(timeouts.legacyIE) || 1000,

--- a/protocolcheck.js
+++ b/protocolcheck.js
@@ -27,12 +27,12 @@ function _createHiddenIframe(target, uri) {
     return iframe;
 }
 
-function openUriWithHiddenFrame(uri, failCb, successCb) {
+function openUriWithHiddenFrame(uri, failCb, successCb, timeoutMs) {
 
     var timeout = setTimeout(function () {
         failCb();
         handler.remove();
-    }, 1000);
+    }, timeoutMs);
 
     var iframe = document.querySelector("#hiddenIframe");
     if (!iframe) {
@@ -50,12 +50,12 @@ function openUriWithHiddenFrame(uri, failCb, successCb) {
     iframe.contentWindow.location.href = uri;
 }
 
-function openUriWithTimeoutHack(uri, failCb, successCb) {
+function openUriWithTimeoutHack(uri, failCb, successCb, timeoutMs) {
     
     var timeout = setTimeout(function () {
         failCb();
         handler.remove();
-    }, 1000);
+    }, timeoutMs);
 
     //handle page running in an iframe (blur must be registered with top level window)
     var target = window;
@@ -91,18 +91,18 @@ function openUriUsingFirefox(uri, failCb, successCb) {
     }
 }
 
-function openUriUsingIEInOlderWindows(uri, failCb, successCb) {
+function openUriUsingIEInOlderWindows(uri, failCb, successCb, timeoutMs) {
     if (getInternetExplorerVersion() === 10) {
-        openUriUsingIE10InWindows7(uri, failCb, successCb);
+        openUriUsingIE10InWindows7(uri, failCb, successCb, timeoutMs);
     } else if (getInternetExplorerVersion() === 9 || getInternetExplorerVersion() === 11) {
-        openUriWithHiddenFrame(uri, failCb, successCb);
+        openUriWithHiddenFrame(uri, failCb, successCb, timeoutMs);
     } else {
-        openUriInNewWindowHack(uri, failCb, successCb);
+        openUriInNewWindowHack(uri, failCb, successCb, timeoutMs);
     }
 }
 
-function openUriUsingIE10InWindows7(uri, failCb, successCb) {
-    var timeout = setTimeout(failCb, 1000);
+function openUriUsingIE10InWindows7(uri, failCb, successCb, timeoutMs) {
+    var timeout = setTimeout(failCb, timeoutMs);
     window.addEventListener("blur", function () {
         clearTimeout(timeout);
         successCb();
@@ -120,7 +120,7 @@ function openUriUsingIE10InWindows7(uri, failCb, successCb) {
     }
 }
 
-function openUriInNewWindowHack(uri, failCb, successCb) {
+function openUriInNewWindowHack(uri, failCb, successCb, timeoutMs) {
     var myWindow = window.open('', '', 'width=0,height=0');
 
     myWindow.document.write("<iframe src='" + uri + "'></iframe>");
@@ -128,13 +128,13 @@ function openUriInNewWindowHack(uri, failCb, successCb) {
     setTimeout(function () {
         try {
             myWindow.location.href;
-            myWindow.setTimeout("window.close()", 1000);
+            myWindow.setTimeout("window.close()", timeoutMs);
             successCb();
         } catch (e) {
             myWindow.close();
             failCb();
         }
-    }, 1000);
+    }, timeoutMs);
 }
 
 function openUriWithMsLaunchUri(uri, failCb, successCb) {
@@ -175,7 +175,15 @@ function getInternetExplorerVersion() {
     return rv;
 }
 
-module.exports = function(uri, failCb, successCb, unsupportedCb) {
+function getTimeouts(timeouts) {
+    return {
+        chromeAndIOS: parseInt(timeouts.chromeAndIOS) || 1000,
+        legacyIE: parseInt(timeouts.legacyIE) || 1000,
+        safari: parseInt(timeouts.safari) || 1000
+    };
+}
+
+module.exports = function(uri, failCb, successCb, unsupportedCb, timeouts) {
     function failCallback() {
         failCb && failCb();
     }
@@ -183,6 +191,8 @@ module.exports = function(uri, failCb, successCb, unsupportedCb) {
     function successCallback() {
         successCb && successCb();
     }
+
+    timeouts = getTimeouts(timeouts);
 
     if (navigator.msLaunchUri) { //for IE and Edge in Win 8 and Win 10
         openUriWithMsLaunchUri(uri, failCb, successCb);
@@ -192,11 +202,11 @@ module.exports = function(uri, failCb, successCb, unsupportedCb) {
         if (browser.isFirefox) {
             openUriUsingFirefox(uri, failCallback, successCallback);
         } else if (browser.isChrome || browser.isIOS) {
-            openUriWithTimeoutHack(uri, failCallback, successCallback);
+            openUriWithTimeoutHack(uri, failCallback, successCallback, timeouts.chromeAndIOS);
         } else if (browser.isIE) {
-            openUriUsingIEInOlderWindows(uri, failCallback, successCallback);
+            openUriUsingIEInOlderWindows(uri, failCallback, successCallback, timeouts.legacyIE);
         } else if (browser.isSafari) {
-            openUriWithHiddenFrame(uri, failCallback, successCallback);
+            openUriWithHiddenFrame(uri, failCallback, successCallback, timeouts.safari);
         } else {
             unsupportedCb();
             //not supported, implement please

--- a/protocolcheck.js
+++ b/protocolcheck.js
@@ -176,6 +176,11 @@ function getInternetExplorerVersion() {
 }
 
 function getTimeouts(timeouts) {
+    timeouts = timeouts || {
+        chromeAndIOS: 1000,
+        legacyIE: 1000,
+        safari: 1000
+    };
     return {
         chromeAndIOS: parseInt(timeouts.chromeAndIOS) || 1000,
         legacyIE: parseInt(timeouts.legacyIE) || 1000,

--- a/protocolcheck.js
+++ b/protocolcheck.js
@@ -176,11 +176,7 @@ function getInternetExplorerVersion() {
 }
 
 function getTimeouts(timeouts) {
-    timeouts = timeouts || {
-        chromeAndIOS: 1000,
-        legacyIE: 1000,
-        safari: 1000
-    };
+    timeouts = timeouts || {};
     return {
         chromeAndIOS: parseInt(timeouts.chromeAndIOS) || 1000,
         legacyIE: parseInt(timeouts.legacyIE) || 1000,


### PR DESCRIPTION
Closes #35
Accepts a new `timeouts` object that contains several properties that
can be used to adjust behavior for slower protocol handlers.